### PR TITLE
Attempt to add %s formatter

### DIFF
--- a/test/60.strftime.js
+++ b/test/60.strftime.js
@@ -20,7 +20,10 @@ describe(TITLE, function() {
       "%a, %b %d %X %Y %z (%Z)": "Tue, Jan 02 03:04:05 2018 +0000 (GMT)",
 
       // Apache Log
-      "%d/%b/%Y:%H:%M:%S %z": "02/Jan/2018:03:04:05 +0000"
+      "%d/%b/%Y:%H:%M:%S %z": "02/Jan/2018:03:04:05 +0000",
+
+      // Decimal epoch seconds
+      "%s.%N": "1514862245.006000000"
     };
 
     Object.keys(FORMATS).forEach(function(format) {
@@ -101,7 +104,7 @@ describe(TITLE, function() {
       // "%P", // Like %p but in lowercase: "am" or "pm" or a corresponding string for the current locale.
       "%R", // The time in 24-hour notation (%H:%M). For a version including the seconds, see %T below.
       // "%r", // The time in a.m. or p.m. notation. In the POSIX locale this is equivalent to %I:%M:%S %p.
-      // "%s", // The number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
+      "%s", // The number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
       "%S", // The second as a decimal number (range 00 to 60). (The range is up to 60 to allow for occasional leap seconds.)
       "%T", // The time in 24-hour notation (%H:%M:%S).
       "%t", // A tab character.

--- a/timestamp.js
+++ b/timestamp.js
@@ -260,7 +260,8 @@ var Timestamp = (function() {
       b: b,
       d: d,
       e: e,
-      m: m
+      m: m,
+      s: s
     };
 
     return strftime(format || FMT_JSON);
@@ -327,6 +328,10 @@ var Timestamp = (function() {
 
     function b() {
       return FMT_MONTH[dt.getUTCMonth()];
+    }
+
+    function s() {
+      return ts.getTimeT();
     }
   }
 


### PR DESCRIPTION
Hello! I tried to add the `%s` format tag, but ran into some issues with timezone handling compared to strftime.

While the implementation was pretty simple (as you can see in the commit diff) the tests started failing when trying to enforce strftime compatibility, like:
```
  4) 60.strftime.js
       strftime compatibility
         2020:

      AssertionError [ERR_ASSERTION]: %s
      + expected - actual

      -1577836800
      +1577865600
```

The difference in seconds is due to my timezone, since I'm UTC-8. To see what was going on, I tried changing how strftime is initialized in `60.strftime.js`:
```js
var strftimeMaker = require("strftime");
var strftime = strftimeMaker.timezone('UTC');
```

This made the `%s` test succeed, but unfortunately another test started failing due to ambiguous timezone parsing:
```
  4) 60.strftime.js
       strftime compatibility
         2020:

      AssertionError [ERR_ASSERTION]: %Y-%m-%dT%H:%M:%S
      + expected - actual

      -2020-01-01T00:00:00
      +2020-01-01T08:00:00
```

So I'm not really sure how to proceed. Do you think this is worth figuring out, or should I just close the PR? I think I could get the use case I wanted (decimal epoch seconds, like `%s.%N`) without adding this tag.